### PR TITLE
Fix typo in lose alert

### DIFF
--- a/assets/script.js
+++ b/assets/script.js
@@ -75,7 +75,7 @@ window.onload = function () {
                     console.log("you remaining guesses: " + remainingGuesses);
                 }
                 if (remainingGuesses === 0) {
-                    alert("You Loose!");
+                    alert("You Lose!");
                 }
                 userGuess.push(playerKey);
             }


### PR DESCRIPTION
## Summary
- fix typo in losing alert text

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688143c62e4c8325ab53dfbde0acd84d