### PR TITLE
Fix footer div attribute spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,7 +63,7 @@
 
 
     <footer class="footer sticky-bottom mt-auto py-3">
-        <div id="footer"class="container text-center">
+        <div id="footer" class="container text-center">
             <span>Copyright &copy;</span>
         </div>
     </footer>


### PR DESCRIPTION
## Summary
- fix spacing between `id` and `class` in footer div

## Testing
- `python3 - <<'EOF'
from html.parser import HTMLParser
class P(HTMLParser):
    def error(self, message):
        print('error', message)
P().feed(open('index.html').read())
print('parsed ok')
EOF`

------
https://chatgpt.com/codex/tasks/task_e_688144987a6483259d8aaf9e79a9db8d