### PR TITLE
Add .gitignore to ignore node artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json


### PR DESCRIPTION
## Summary
- prevent node dependencies and lockfile from being added to version control by adding `.gitignore`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68814c564c1c8325a14af63891b89f59