### PR TITLE
Add edge-case tests for findLetterIndices

### DIFF
--- a/tests/game.test.js
+++ b/tests/game.test.js
@@ -9,3 +9,15 @@ test('findLetterIndices finds all repeated letters', () => {
   expect(findLetterIndices('Mississippi', 's')).toEqual([2,3,5,6]);
   expect(findLetterIndices('apple', 'p')).toEqual([1,2]);
 });
+
+test('findLetterIndices works with array input', () => {
+  expect(findLetterIndices(['A', 'b'], 'a')).toEqual([0]);
+  expect(findLetterIndices(['A', 'b'], 'b')).toEqual([1]);
+});
+
+test('findLetterIndices handles empty or undefined arguments', () => {
+  expect(findLetterIndices('', 'a')).toEqual([]);
+  expect(findLetterIndices('hello', '')).toEqual([]);
+  expect(findLetterIndices(undefined, 'a')).toEqual([]);
+  expect(findLetterIndices('hello', undefined)).toEqual([]);
+});


### PR DESCRIPTION
## Summary
- test arrays passed to `findLetterIndices`
- test empty string and undefined arguments to `findLetterIndices`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6881690112648325829f3623639acfea